### PR TITLE
feat: ClockControlButton 구현

### DIFF
--- a/Clock/Clock/Presentation/Component/ClockControlButton.swift
+++ b/Clock/Clock/Presentation/Component/ClockControlButton.swift
@@ -1,0 +1,53 @@
+//
+//  ClockControlButton.swift
+//  Clock
+//
+//  Created by 이수현 on 5/20/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class ClockControlButton: UIButton {
+    private let type: ClockControlButtonType
+    private let disposeBag = DisposeBag()
+
+    override var isSelected: Bool {
+        didSet {
+            self.backgroundColor = self.isSelected ? type.selectedBackground : type.backgroundColor
+        }
+    }
+
+    init(type: ClockControlButtonType) {
+        self.type = type
+        super.init(frame: .zero)
+
+        setAttributes()
+        setBindings()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+}
+
+private extension ClockControlButton {
+    func setAttributes() {
+        self.setTitle(type.title, for: .normal)
+        self.setTitle(type.selectedTitle, for: .selected)
+        self.setTitleColor(type.titleColor, for: .normal)
+        self.setTitleColor(type.selectedTitleColor, for: .selected)
+        self.backgroundColor = type.backgroundColor
+    }
+
+    func setBindings() {
+        self.rx.tap
+            .bind {[weak self]_ in
+                guard let self else { return }
+                self.isSelected.toggle()
+            }.disposed(by: disposeBag)
+    }
+}

--- a/Clock/Clock/Presentation/Component/ClockControlButton.swift
+++ b/Clock/Clock/Presentation/Component/ClockControlButton.swift
@@ -16,7 +16,7 @@ final class ClockControlButton: UIButton {
 
     override var isSelected: Bool {
         didSet {
-            self.backgroundColor = self.isSelected ? type.selectedBackground : type.backgroundColor
+            self.backgroundColor = self.isSelected ? type.selectedBackgroundColor : type.backgroundColor
         }
     }
 

--- a/Clock/Clock/Presentation/Component/ClockControlButtonType.swift
+++ b/Clock/Clock/Presentation/Component/ClockControlButtonType.swift
@@ -1,0 +1,83 @@
+//
+//  ClockControlButtonType.swift
+//  Clock
+//
+//  Created by 이수현 on 5/20/25.
+//
+
+import UIKit
+
+enum ClockControlButtonType {
+    case restartAndStop
+    case rep
+    case start
+    case cancel
+}
+
+extension ClockControlButtonType {
+    var title: String {
+        switch self {
+        case .restartAndStop:
+            return "재개"
+        case .start:
+            return "시작"
+        case .rep:
+            return "랩"
+        case .cancel:
+            return "취소"
+        }
+    }
+
+    var selectedTitle: String {
+        switch self {
+        case .restartAndStop:
+            return "일시 정지"
+        case .start:
+            return "중단"
+        case .rep, .cancel:
+            return title
+        }
+    }
+
+    var titleColor: UIColor {
+        switch self {
+        case .restartAndStop, .start:
+            return .green
+        case .rep, .cancel:
+            return .white
+        }
+    }
+
+    var selectedTitleColor: UIColor {
+        switch self {
+        case .restartAndStop:
+            return .orange
+        case .start:
+            return .red
+        case .rep:
+            return .white
+        case .cancel:
+            return .white.withAlphaComponent(0.2)
+        }
+    }
+
+    var backgroundColor: UIColor {
+        switch self {
+        case .restartAndStop, .start:
+            return .green.withAlphaComponent(0.2)
+        case .rep, .cancel:
+            return .gray.withAlphaComponent(0.2)
+        }
+    }
+
+    var selectedBackground: UIColor {
+        switch self {
+        case .restartAndStop:
+            return .orange.withAlphaComponent(0.2)
+        case .start:
+            return .red.withAlphaComponent(0.2)
+        case .rep, .cancel:
+            return backgroundColor
+        }
+    }
+}

--- a/Clock/Clock/Presentation/Component/ClockControlButtonType.swift
+++ b/Clock/Clock/Presentation/Component/ClockControlButtonType.swift
@@ -9,7 +9,7 @@ import UIKit
 
 enum ClockControlButtonType {
     case restartAndStop
-    case rep
+    case lap
     case start
     case cancel
 }
@@ -21,7 +21,7 @@ extension ClockControlButtonType {
             return "재개"
         case .start:
             return "시작"
-        case .rep:
+        case .lap:
             return "랩"
         case .cancel:
             return "취소"
@@ -34,7 +34,7 @@ extension ClockControlButtonType {
             return "일시 정지"
         case .start:
             return "중단"
-        case .rep, .cancel:
+        case .lap, .cancel:
             return title
         }
     }
@@ -43,7 +43,7 @@ extension ClockControlButtonType {
         switch self {
         case .restartAndStop, .start:
             return .green
-        case .rep, .cancel:
+        case .lap, .cancel:
             return .white
         }
     }
@@ -54,7 +54,7 @@ extension ClockControlButtonType {
             return .orange
         case .start:
             return .red
-        case .rep:
+        case .lap:
             return .white
         case .cancel:
             return .white.withAlphaComponent(0.2)
@@ -65,18 +65,18 @@ extension ClockControlButtonType {
         switch self {
         case .restartAndStop, .start:
             return .green.withAlphaComponent(0.2)
-        case .rep, .cancel:
+        case .lap, .cancel:
             return .gray.withAlphaComponent(0.2)
         }
     }
 
-    var selectedBackground: UIColor {
+    var selectedBackgroundColor: UIColor {
         switch self {
         case .restartAndStop:
             return .orange.withAlphaComponent(0.2)
         case .start:
             return .red.withAlphaComponent(0.2)
-        case .rep, .cancel:
+        case .lap, .cancel:
             return backgroundColor
         }
     }


### PR DESCRIPTION
스톱워치와 타이머의 시간을 컨트롤 하는 공통 컴포넌트입니다.

버튼의 타입은 아래와 같이 구성됩니다
1. 재개 / 일시정지
2. 시작 / 중단
3. 랩
4. 취소

랩 버튼의 경우, isSelected로 구분하면 랩 기록을 남길 때마다 titleColor가 바뀔 거 같아서 우선은 구분하지 않았고 재설정 텍스트도 따로 configure로 넣어줘야 될 듯 합니다.
추가적으로 isSelected로 구분하는 게 버튼 탭 시 화면 이동이 포함된다면 UI가 바뀌면서 이동할 듯 싶어요
이 부분은 화면 구현하면서 추가적으로 수정해야 될 것 같습니다.

타이머에서 이미지로 구성된 재생 / 정지 버튼도 따로 구현해야 될 것 같습니다.

피드백 부탁드립니다!

## 테스트 영상
![Simulator Screen Recording - iPhone 13 mini - 2025-05-20 at 20 42 36](https://github.com/user-attachments/assets/12c48391-d1ca-4512-a955-1156b61001ba)
