### PR TITLE
feat: 뷰 식별을 위한 ReuseIdentifier 프로토콜 추가

### DIFF
--- a/Clock/Clock/Presentation/Extension/ReuseIdentifier.swift
+++ b/Clock/Clock/Presentation/Extension/ReuseIdentifier.swift
@@ -1,0 +1,9 @@
+protocol ReuseIdentifier {
+    static var identifier: String { get }
+}
+
+extension ReuseIdentifier {
+    static var identifier: String {
+        String(describing: self)
+    }
+}


### PR DESCRIPTION
뷰에 채택해서 `identifier`를 사용할 수 있도록 프로토콜 정의했습니다.
우선 Extension에 뒀는데, 더 좋은 의견 있으시면 말씀해주세요.