### PR TITLE
feat: 알람 화면 구현

### DIFF
--- a/Clock/Clock/App/DIContainer.swift
+++ b/Clock/Clock/App/DIContainer.swift
@@ -4,6 +4,6 @@ final class DIContainer {
     }
 
     func makeAlarmViewModel() -> AlarmViewModel {
-        AlarmViewModelImpl(fetchAlarmUseCase: makeFetchableAlarmUseCase())
+        DefaultAlarmViewModel(fetchAlarmUseCase: makeFetchableAlarmUseCase())
     }
 }

--- a/Clock/Clock/App/DIContainer.swift
+++ b/Clock/Clock/App/DIContainer.swift
@@ -1,0 +1,9 @@
+final class DIContainer {
+    func makeFetchableAlarmUseCase() -> FetchableAlarmUseCase {
+        FetchAlarmUseCase()
+    }
+
+    func makeAlarmViewModel() -> AlarmViewModel {
+        AlarmViewModelImpl(fetchAlarmUseCase: makeFetchableAlarmUseCase())
+    }
+}

--- a/Clock/Clock/App/SceneDelegate.swift
+++ b/Clock/Clock/App/SceneDelegate.swift
@@ -18,7 +18,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .background
-        window?.rootViewController = BaseTabBarViewController()
+        window?.rootViewController = BaseTabBarViewController(diContainer: DIContainer())
         window?.makeKeyAndVisible()
     }
 }

--- a/Clock/Clock/Domain/Interface/UseCase/FetchableAlarmUseCase.swift
+++ b/Clock/Clock/Domain/Interface/UseCase/FetchableAlarmUseCase.swift
@@ -1,0 +1,3 @@
+protocol FetchableAlarmUseCase {
+    func execute() async throws -> [AlarmGroup]
+}

--- a/Clock/Clock/Domain/Model/Alarm.swift
+++ b/Clock/Clock/Domain/Model/Alarm.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct AlarmGroup {
+    let id: UUID
+    let name: String
+    let order: Int
+    let alarms: [Alarm]
+}
+
+struct Alarm {
+    let id: UUID
+    let hour: Int
+    let minute: Int
+    let label: String
+    let sound: Sound
+    let isSnooze: Bool
+    let isEnabled: Bool
+    let repeatDays: [RepeatDay]
+}
+
+struct RepeatDay {
+    let weekday: Int
+}

--- a/Clock/Clock/Domain/UseCase/FetchAlarmUseCase.swift
+++ b/Clock/Clock/Domain/UseCase/FetchAlarmUseCase.swift
@@ -1,0 +1,5 @@
+final class FetchAlarmUseCase: FetchableAlarmUseCase {
+    func execute() async throws -> [AlarmGroup] {
+        []
+    }
+}

--- a/Clock/Clock/Domain/UseCase/FetchAlarmUseCase.swift
+++ b/Clock/Clock/Domain/UseCase/FetchAlarmUseCase.swift
@@ -2,4 +2,33 @@ final class FetchAlarmUseCase: FetchableAlarmUseCase {
     func execute() async throws -> [AlarmGroup] {
         []
     }
+
+    private func sort(_ groups: [AlarmGroup]) -> [AlarmGroup] {
+        groups.map { group in
+            let sortedAlarms = group.alarms
+                .map { alarm in
+                    let sortedRepeatDays = alarm.repeatDays.sorted { $0.weekday < $1.weekday }
+
+                    return Alarm(
+                        id: alarm.id,
+                        hour: alarm.hour,
+                        minute: alarm.minute,
+                        label: alarm.label,
+                        sound: alarm.sound,
+                        isSnooze: alarm.isSnooze,
+                        isEnabled: alarm.isEnabled,
+                        repeatDays: sortedRepeatDays
+                    )
+                }
+                .sorted { ($0.hour, $0.minute) < ($1.hour, $1.minute) }
+
+            return AlarmGroup(
+                id: group.id,
+                name: group.name,
+                order: group.order,
+                alarms: sortedAlarms
+            )
+        }
+        .sorted { $0.order < $1.order }
+    }
 }

--- a/Clock/Clock/Presentation/Model/AlarmDisplay.swift
+++ b/Clock/Clock/Presentation/Model/AlarmDisplay.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+enum AlarmSection: Hashable {
+    case group(AlarmGroupDisplay)
+}
+
+struct AlarmGroupDisplay: Hashable {
+    let id: UUID
+    var name: String
+    var order: Int
+    var alarms: [AlarmDisplay]
+
+    static func == (lhs: AlarmGroupDisplay, rhs: AlarmGroupDisplay) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+struct AlarmDisplay: Hashable {
+    let id: UUID
+    var meridiem: String?
+    var time: String
+    var labelAndRepeatDays: String
+    var isEnabled: Bool
+
+    init(alarm: Alarm) {
+        self.id = alarm.id
+        self.isEnabled = alarm.isEnabled
+        self.meridiem = AlarmDisplayFormatter.formatMeridiem(hour: alarm.hour)
+        self.time = AlarmDisplayFormatter.formatTime(hour: alarm.hour, minute: alarm.minute)
+        self.labelAndRepeatDays = AlarmDisplayFormatter.makeLabelAndRepeatDays(
+            label: alarm.label,
+            repeatDays: alarm.repeatDays
+        )
+    }
+
+    static func == (lhs: AlarmDisplay, rhs: AlarmDisplay) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+enum AlarmDisplayFormatter {
+    private static let calendar = Calendar.current
+
+    private static let meridiemFormatter: DateFormatter = {
+        let formatter = makeFormatter(dateFormat: "a")
+        formatter.amSymbol = "오전"
+        formatter.pmSymbol = "오후"
+        return formatter
+    }()
+
+    private static let timeFormatter12: DateFormatter = makeFormatter(dateFormat: "h:mm")
+    private static let timeFormatter24: DateFormatter = makeFormatter(dateFormat: "H:mm")
+
+    private static let weekdaySymbols: [String] = {
+        let formatter = makeFormatter()
+        return formatter.shortStandaloneWeekdaySymbols
+    }()
+
+    private static func makeFormatter(dateFormat: String? = nil) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        if let dateFormat = dateFormat {
+            formatter.dateFormat = dateFormat
+        }
+        return formatter
+    }
+
+    static func formatMeridiem(hour: Int) -> String? {
+        guard isUsing12HourFormat() else { return nil }
+
+        let date = calendar.date(from: DateComponents(hour: hour))!
+
+        return meridiemFormatter.string(from: date)
+    }
+
+    static func formatTime(hour: Int, minute: Int) -> String {
+        let date = calendar.date(from: DateComponents(hour: hour, minute: minute))!
+
+        return isUsing12HourFormat() ? timeFormatter12.string(from: date) : timeFormatter24.string(from: date)
+    }
+
+    static func makeLabelAndRepeatDays(label: String, repeatDays: [RepeatDay]) -> String {
+        let repeatText = makeRepeatDays(from: repeatDays)
+
+        switch (label.isEmpty, repeatText.isEmpty) {
+        case (true, true): return ""
+        case (true, false): return repeatText
+        case (false, true): return label
+        case (false, false): return "\(label), \(repeatText)"
+        }
+    }
+
+    private static func isUsing12HourFormat() -> Bool {
+        let format = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: Locale.current)!
+
+        return format.contains("a")
+    }
+
+    private static func makeRepeatDays(from repeatDays: [RepeatDay]) -> String {
+        guard !repeatDays.isEmpty else { return "" }
+
+        let weekdays = repeatDays.map { $0.weekday }.sorted()
+
+        if weekdays.count == 7 { return "매일" }
+        if weekdays == [2, 3, 4, 5, 6] { return "주중" }
+        if weekdays == [1, 7] { return "주말" }
+
+        let symbols = weekdays.map { weekdaySymbols[($0 - 1) % 7] }
+
+        if symbols.count > 1 {
+            let last = symbols.last!
+            let rest = symbols.dropLast().joined(separator: ", ")
+
+            return "\(rest) 및 \(last)"
+        } else {
+            return symbols.first!
+        }
+    }
+}

--- a/Clock/Clock/Presentation/Model/AlarmDisplay.swift
+++ b/Clock/Clock/Presentation/Model/AlarmDisplay.swift
@@ -57,7 +57,7 @@ enum AlarmDisplayFormatter {
     }()
 
     private static let timeFormatter12: DateFormatter = makeFormatter(dateFormat: "h:mm")
-    private static let timeFormatter24: DateFormatter = makeFormatter(dateFormat: "H:mm")
+    private static let timeFormatter24: DateFormatter = makeFormatter(dateFormat: "HH:mm")
 
     private static let weekdaySymbols: [String] = {
         let formatter = makeFormatter()

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/AlarmViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/AlarmViewController.swift
@@ -38,9 +38,7 @@ final class AlarmViewController: UIViewController {
     private func applySnapshot(with groups: [AlarmGroupDisplay]) {
         var snapshot = NSDiffableDataSourceSnapshot<AlarmSection, AlarmDisplay>()
 
-        let sortedGroups = groups.sorted(by: { $0.order < $1.order })
-
-        for group in sortedGroups {
+        for group in groups {
             let section = AlarmSection.group(group)
             snapshot.appendSections([section])
             snapshot.appendItems(group.alarms, toSection: section)

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/AlarmViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/AlarmViewController.swift
@@ -1,0 +1,145 @@
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class AlarmViewController: UIViewController {
+    private let alarmViewModel: AlarmViewModel
+
+    private let disposeBag = DisposeBag()
+
+    private let editButton = BarButtonFactory.editButton()
+    private let plusButton = BarButtonFactory.plusButton()
+    private let alarmTableView = AlarmTableView(frame: .zero, style: .grouped)
+    private var dataSource: UITableViewDiffableDataSource<AlarmSection, AlarmDisplay>!
+
+    init(alarmViewModel: AlarmViewModel) {
+        self.alarmViewModel = alarmViewModel
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+        setDataSource()
+        setBindings()
+
+        alarmViewModel.viewDidLoad.onNext(())
+    }
+
+    private func applySnapshot(with groups: [AlarmGroupDisplay]) {
+        var snapshot = NSDiffableDataSourceSnapshot<AlarmSection, AlarmDisplay>()
+
+        let sortedGroups = groups.sorted(by: { $0.order < $1.order })
+
+        for group in sortedGroups {
+            let section = AlarmSection.group(group)
+            snapshot.appendSections([section])
+            snapshot.appendItems(group.alarms, toSection: section)
+        }
+
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}
+
+private extension AlarmViewController {
+    func setAttributes() {
+        navigationItem.leftBarButtonItem = editButton
+        navigationItem.rightBarButtonItem = plusButton
+
+        title = "알람"
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+    func setHierarchy() {
+        view.addSubview(alarmTableView)
+    }
+
+    func setConstraints() {
+        alarmTableView.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(16)
+            $0.verticalEdges.right.equalToSuperview()
+        }
+    }
+
+    func setDataSource() {
+        dataSource = UITableViewDiffableDataSource<AlarmSection, AlarmDisplay>(
+            tableView: alarmTableView
+        ) { tableView, indexPath, alarm in
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: AlarmCell.identifier,
+                for: indexPath
+            ) as? AlarmCell else { return UITableViewCell() }
+
+            cell.configure(with: alarm)
+            cell.enabledSwitch.rx.isOn
+                .skip(1)
+                .distinctUntilChanged()
+                .bind(with: self) { owner, isOn in
+                    cell.configureLabelColor(with: isOn)
+
+                    if let indexPath = owner.alarmTableView.indexPath(for: cell),
+                       case let .group(groupDisplay) = owner.dataSource.snapshot().sectionIdentifiers[indexPath.section] {
+                        let groupID = groupDisplay.id
+                        let alarmID = alarm.id
+
+                        owner.alarmViewModel.toggleSwitch.onNext((groupID, alarmID, isOn))
+                    }
+                }
+                .disposed(by: cell.disposeBag)
+
+            return cell
+        }
+
+        dataSource.defaultRowAnimation = .fade
+    }
+
+    func setBindings() {
+        editButton.rx.tap
+            .bind { [weak self] in
+            }
+            .disposed(by: disposeBag)
+
+        plusButton.rx.tap
+            .bind { [weak self] in
+            }
+            .disposed(by: disposeBag)
+
+        alarmViewModel.alarmGroups
+            .asDriver(onErrorJustReturn: [])
+            .drive(onNext: { [weak self] groups in
+                self?.applySnapshot(with: groups)
+            })
+            .disposed(by: disposeBag)
+
+        alarmTableView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+    }
+}
+
+extension AlarmViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: AlarmSectionHeaderView.identifier) as? AlarmSectionHeaderView else {
+            return nil
+        }
+
+        let sectionIdentifier = dataSource.snapshot().sectionIdentifiers[section]
+        if case let .group(groupDisplay) = sectionIdentifier {
+            headerView.configure(title: groupDisplay.name)
+        }
+
+        return headerView
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 44
+    }
+}

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmCell.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmCell.swift
@@ -51,7 +51,7 @@ private extension AlarmCell {
 
         meridiemLabel.font = .systemFont(ofSize: 24, weight: .semibold)
 
-        timeLabel.font = .systemFont(ofSize: 48)
+        timeLabel.font = .systemFont(ofSize: 56, weight: .light)
 
         labelAndRepeatDaysLabel.font = .systemFont(ofSize: 14)
         labelAndRepeatDaysLabel.numberOfLines = 0

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmCell.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmCell.swift
@@ -1,0 +1,90 @@
+import UIKit
+import RxSwift
+
+final class AlarmCell: UITableViewCell, ReuseIdentifier {
+    private let timeStackView = UIStackView()
+    private let meridiemLabel = UILabel()
+    private let timeLabel = UILabel()
+    private let labelAndRepeatDaysLabel = UILabel()
+    private let repeatLabel = UILabel()
+    let enabledSwitch = UISwitch()
+
+    private(set) var disposeBag = DisposeBag()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    func configure(with alarm: AlarmDisplay) {
+        meridiemLabel.text = alarm.meridiem
+        timeLabel.text = alarm.time
+        labelAndRepeatDaysLabel.text = alarm.labelAndRepeatDays
+        enabledSwitch.isOn = alarm.isEnabled
+
+        configureLabelColor(with: alarm.isEnabled)
+    }
+
+    func configureLabelColor(with isEnabled: Bool) {
+        let color: UIColor = isEnabled ? .label : .secondaryLabel
+        [meridiemLabel, timeLabel, labelAndRepeatDaysLabel]
+            .forEach { $0.textColor = color }
+    }
+}
+
+private extension AlarmCell {
+    func setAttributes() {
+        backgroundColor = .clear
+
+        separatorInset = .zero
+
+        timeStackView.axis = .horizontal
+        timeStackView.spacing = 2
+        timeStackView.alignment = .lastBaseline
+
+        meridiemLabel.font = .systemFont(ofSize: 24, weight: .semibold)
+
+        timeLabel.font = .systemFont(ofSize: 48)
+
+        labelAndRepeatDaysLabel.font = .systemFont(ofSize: 14)
+        labelAndRepeatDaysLabel.numberOfLines = 0
+    }
+
+
+    func setHierarchy() {
+        [meridiemLabel, timeLabel]
+            .forEach { timeStackView.addArrangedSubview($0) }
+
+        [timeStackView, labelAndRepeatDaysLabel, enabledSwitch]
+            .forEach { contentView.addSubview($0) }
+    }
+
+    func setConstraints() {
+        timeStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.equalToSuperview().inset(8)
+        }
+
+        enabledSwitch.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+
+        labelAndRepeatDaysLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.equalTo(timeStackView.snp.bottom).offset(8)
+            $0.trailing.lessThanOrEqualTo(enabledSwitch.snp.leading).offset(-8)
+            $0.bottom.equalToSuperview().inset(16)
+        }
+
+        labelAndRepeatDaysLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+
+}

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmSectionHeaderView.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmSectionHeaderView.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+final class AlarmSectionHeaderView: UITableViewHeaderFooterView, ReuseIdentifier {
+    private let headerLabel = UILabel()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    func configure(title: String) {
+        headerLabel.text = title
+    }
+}
+
+extension AlarmSectionHeaderView {
+    func setAttributes() {
+        headerLabel.font = .boldSystemFont(ofSize: 20)
+        headerLabel.textColor = .label
+    }
+
+    func setHierarchy() {
+        contentView.addSubview(headerLabel)
+    }
+
+    func setConstraints() {
+        headerLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.verticalEdges.trailing.equalToSuperview()
+        }
+    }
+}

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmTableView.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/Subview/AlarmTableView.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+final class AlarmTableView: UITableView {
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+
+        setAttributes()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+}
+
+private extension AlarmTableView {
+    func setAttributes() {
+        showsVerticalScrollIndicator = false
+        register(AlarmCell.self, forCellReuseIdentifier: AlarmCell.identifier)
+        register(AlarmSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: AlarmSectionHeaderView.identifier)
+    }
+}

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewModel/AlarmViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewModel/AlarmViewModel.swift
@@ -1,0 +1,13 @@
+import RxSwift
+import Foundation
+
+protocol AlarmViewModel: AlarmViewModelInput, AlarmViewModelOutput {}
+
+protocol AlarmViewModelInput {
+    var viewDidLoad: AnyObserver<Void> { get }
+    var toggleSwitch: AnyObserver<(groupID: UUID, alarmID: UUID, isOn: Bool)> { get }
+}
+
+protocol AlarmViewModelOutput {
+    var alarmGroups: Observable<[AlarmGroupDisplay]> { get }
+}

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewModel/AlarmViewModelImpl.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewModel/AlarmViewModelImpl.swift
@@ -1,0 +1,84 @@
+import Foundation
+import RxSwift
+import RxRelay
+
+final class AlarmViewModelImpl: AlarmViewModel {
+    private let fetchAlarmUseCase: FetchableAlarmUseCase
+    private let disposeBag = DisposeBag()
+
+    let viewDidLoad: AnyObserver<Void>
+    let toggleSwitch: AnyObserver<(groupID: UUID, alarmID: UUID, isOn: Bool)>
+
+    let alarmGroups: Observable<[AlarmGroupDisplay]>
+
+    private let viewDidLoadSubject = PublishSubject<Void>()
+    private let toggleSwitchSubject = PublishSubject<(groupID: UUID, alarmID: UUID, isOn: Bool)>()
+
+    private let alarmGroupsRelay = BehaviorRelay<[AlarmGroupDisplay]>(value: [])
+
+    private var currentGroups: [AlarmGroupDisplay] = []
+
+    init(fetchAlarmUseCase: FetchableAlarmUseCase) {
+        self.fetchAlarmUseCase = fetchAlarmUseCase
+
+        self.viewDidLoad = viewDidLoadSubject.asObserver()
+        self.toggleSwitch = toggleSwitchSubject.asObserver()
+
+        self.alarmGroups = alarmGroupsRelay.asObservable()
+
+        bind()
+    }
+
+    private func bind() {
+        viewDidLoadSubject
+            .flatMapLatest { [weak self] _ -> Observable<[AlarmGroupDisplay]> in
+                guard let self else { return .empty() }
+                return Observable.create { observer in
+                    Task {
+                        do {
+                            let domainGroups = try await self.fetchAlarmUseCase.execute()
+                            let displayGroups = self.mapToAlarmGroupDisplay(domainGroups)
+                                .sorted(by: { $0.order < $1.order })
+                            observer.onNext(displayGroups)
+                            observer.onCompleted()
+                        } catch {
+                            observer.onError(error)
+                        }
+                    }
+                    return Disposables.create()
+                }
+            }
+            .subscribe(onNext: { [weak self] groups in
+                self?.currentGroups = groups
+                self?.alarmGroupsRelay.accept(groups)
+            })
+            .disposed(by: disposeBag)
+
+        toggleSwitchSubject
+            .subscribe(onNext: { [weak self] groupID, alarmID, isOn in
+                self?.updateAlarmEnabled(groupID: groupID, alarmID: alarmID, isEnabled: isOn)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func updateAlarmEnabled(groupID: UUID, alarmID: UUID, isEnabled: Bool) {
+        guard let groupIndex = currentGroups.firstIndex(where: { $0.id == groupID }) else { return }
+        guard let alarmIndex = currentGroups[groupIndex].alarms.firstIndex(where: { $0.id == alarmID }) else { return }
+
+        currentGroups[groupIndex].alarms[alarmIndex].isEnabled = isEnabled
+        alarmGroupsRelay.accept(currentGroups)
+    }
+
+    private func mapToAlarmGroupDisplay(_ domainGroups: [AlarmGroup]) -> [AlarmGroupDisplay] {
+        domainGroups.map { group in
+            AlarmGroupDisplay(
+                id: group.id,
+                name: group.name,
+                order: group.order,
+                alarms: group.alarms.map { alarm in
+                    return AlarmDisplay(alarm: alarm)
+                }
+            )
+        }
+    }
+}

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewModel/AlarmViewModelImpl.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewModel/AlarmViewModelImpl.swift
@@ -38,7 +38,7 @@ final class AlarmViewModelImpl: AlarmViewModel {
                         do {
                             let domainGroups = try await self.fetchAlarmUseCase.execute()
                             let displayGroups = self.mapToAlarmGroupDisplay(domainGroups)
-                                .sorted(by: { $0.order < $1.order })
+                            
                             observer.onNext(displayGroups)
                             observer.onCompleted()
                         } catch {

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewModel/DefaultAlarmViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewModel/DefaultAlarmViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import RxSwift
 import RxRelay
 
-final class AlarmViewModelImpl: AlarmViewModel {
+final class DefaultAlarmViewModel: AlarmViewModel {
     private let fetchAlarmUseCase: FetchableAlarmUseCase
     private let disposeBag = DisposeBag()
 

--- a/Clock/Clock/Presentation/TabBar/BaseTabBarViewController.swift
+++ b/Clock/Clock/Presentation/TabBar/BaseTabBarViewController.swift
@@ -8,6 +8,19 @@
 import UIKit
 
 final class BaseTabBarViewController: UITabBarController {
+    let diContainer: DIContainer
+
+    init(diContainer: DIContainer) {
+        self.diContainer = diContainer
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         start()
@@ -23,9 +36,11 @@ final class BaseTabBarViewController: UITabBarController {
     private func makeViewController(type: TabBarItemType) -> UIViewController {
         switch type {
         case .alarm:
-            let vc = ViewController() // TODO: 지성님 수정
-            vc.tabBarItem = makeTabBarItem(type: type)
-            return vc
+            let vm = diContainer.makeAlarmViewModel()
+            let vc = AlarmViewController(alarmViewModel: vm)
+            let nav = UINavigationController(rootViewController: vc)
+            nav.tabBarItem = makeTabBarItem(type: type)
+            return nav
         case .stopwatch:
             let vc = ViewController()
             vc.tabBarItem = makeTabBarItem(type: type)

--- a/Clock/Clock/Presentation/TabBar/Type/TabBarItemType.swift
+++ b/Clock/Clock/Presentation/TabBar/Type/TabBarItemType.swift
@@ -16,7 +16,7 @@ enum TabBarItemType: CaseIterable {
 extension TabBarItemType {
     var title: String {
         switch self {
-        case .alarm: "알림"
+        case .alarm: "알람"
         case .stopwatch: "스톱워치"
         case .timer: "타이머"
         }


### PR DESCRIPTION
`DIContainer`를 `BaseTabBarViewController`의 생성자를 통해 주입하고 있는데, 굳이 그럴 필요까진 없어보이긴 합니다.
`BaseTabBarViewController` 안에서 직접 생성해도 되지 않을까 싶습니다.

아이폰 알람처럼 앱이 백그라운드 -> 포그라운드 될 때, 시스템 설정(24시간 or 12시간)에 따라 변경하고 싶은데, 잘 안되어서 도전으로 미뤄두겠습니다..

목 데이터는 아래 클래스를 사용하시면 됩니다.
```swift
import Foundation

final class MockFetchAlarmUseCase: FetchableAlarmUseCase {
    func execute() async throws -> [AlarmGroup] {
        return makeMockAlarmGroups(10).sorted(by: { $0.order < $1.order })
    }

    private func makeMockAlarmGroups(_ count: Int) -> [AlarmGroup] {
        (1...count).map { index in
            AlarmGroup(
                id: UUID(),
                name: "그룹\(index)",
                order: index,
                alarms: (1...Int.random(in: 1...5)).map { _ in makeMockAlarm() }
            )
        }
    }

    private func makeMockAlarm() -> Alarm {
        Alarm(
            id: UUID(),
            hour: Int.random(in: 0...23),
            minute: Int.random(in: 0...59),
            label: ["레이블1", "레이블2", "가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
                .randomElement()!,
            sound: .none,
            isSnooze: Bool.random(),
            isEnabled: Bool.random(),
            repeatDays: makeMockRepeatDays()
        )
    }

    private func makeMockRepeatDays() -> [RepeatDay] {
        let repeatDay = (1...7).shuffled().prefix(Int.random(in: 0...7))

        return repeatDay.map { RepeatDay(weekday: $0) }
    }
}
```

https://github.com/user-attachments/assets/857af0e0-8e1f-48d5-8229-19ea60942483

https://github.com/user-attachments/assets/8f9245b2-42f1-4222-a6bf-f5d7fbc9b711