### PR TITLE
[Feat] CoreData 스키마 정의, AlarmGroupEntity CRUD 구현

### DIFF
--- a/Clock/Clock/Data/Error/CoreDataError.swift
+++ b/Clock/Clock/Data/Error/CoreDataError.swift
@@ -1,0 +1,16 @@
+//
+//  CoreDataError.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/21/25.
+//
+
+import Foundation
+
+enum CoreDataError: Error {
+    case deallocated
+    case fetchFailed(String)
+    case insertFailed(String)
+    case updateFailed(String)
+    case deleteFailed(String)
+}

--- a/Clock/Clock/Data/Error/CoreDataError.swift
+++ b/Clock/Clock/Data/Error/CoreDataError.swift
@@ -13,4 +13,5 @@ enum CoreDataError: Error {
     case insertFailed(String)
     case updateFailed(String)
     case deleteFailed(String)
+    case entityNotFound
 }

--- a/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
+++ b/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
@@ -1,0 +1,17 @@
+//
+//  AlarmStorage.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/21/25.
+//
+
+import CoreData
+
+protocol AlarmStorage {
+    func fetchAlarmGroups<DomainEntity>(
+        _ mapped: @escaping (AlarmGroupEntity) -> DomainEntity
+    ) async -> Result<[DomainEntity], CoreDataError>
+    func insertAlarmGroup(
+        _ mapped: @escaping (NSManagedObjectContext) -> AlarmGroupEntity
+    ) async -> Result<Void, CoreDataError>
+}

--- a/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
+++ b/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
@@ -14,4 +14,9 @@ protocol AlarmStorage {
     func insertAlarmGroup(
         _ mapped: @escaping (NSManagedObjectContext) -> AlarmGroupEntity
     ) async -> Result<Void, CoreDataError>
+    func updateAlarmGroup(
+        predicate: NSPredicate,
+        _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmGroupEntity
+    ) async -> Result<Void, CoreDataError>
+    func deleteAlarmGroup(by id: UUID) async -> Result<Void, CoreDataError>
 }

--- a/Clock/Clock/Data/Model/AlarmEntity.swift
+++ b/Clock/Clock/Data/Model/AlarmEntity.swift
@@ -1,0 +1,21 @@
+//
+//  AlarmEntity.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/21/25.
+//
+
+import CoreData
+
+@objc(Alarm)
+public class AlarmEntity: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var hour: Int16
+    @NSManaged public var minute: Int16
+    @NSManaged public var label: String
+    @NSManaged public var sound: String
+    @NSManaged public var isSnooze: Bool
+    @NSManaged public var isEnabled: Bool
+    @NSManaged public var repeatDays: Set<RepeatDayEntity>?
+    @NSManaged public var alarmGroup: AlarmGroupEntity?
+}

--- a/Clock/Clock/Data/Model/AlarmGroupEntity.swift
+++ b/Clock/Clock/Data/Model/AlarmGroupEntity.swift
@@ -1,0 +1,16 @@
+//
+//  AlarmGroupEntity.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/21/25.
+//
+
+import CoreData
+
+@objc(AlarmGroup)
+public class AlarmGroupEntity: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var name: String
+    @NSManaged public var order: Int16
+    @NSManaged public var alarms: Set<AlarmEntity>?
+}

--- a/Clock/Clock/Data/Model/AlarmModel.xcdatamodeld/AlarmModel.xcdatamodel/contents
+++ b/Clock/Clock/Data/Model/AlarmModel.xcdatamodeld/AlarmModel.xcdatamodel/contents
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Alarm" representedClassName="Alarm" syncable="YES">
+        <attribute name="hour" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isEnable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSnooze" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="label" attributeType="String" defaultValueString=""/>
+        <attribute name="minute" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sound" attributeType="String" defaultValueString=""/>
+        <relationship name="alarmGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AlarmGroup" inverseName="alarms" inverseEntity="AlarmGroup"/>
+        <relationship name="repeatDays" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="RepeatDay" inverseName="alarm" inverseEntity="RepeatDay"/>
+    </entity>
+    <entity name="AlarmGroup" representedClassName="AlarmGroup" syncable="YES">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="alarms" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Alarm" inverseName="alarmGroup" inverseEntity="Alarm"/>
+    </entity>
+    <entity name="RepeatDay" representedClassName="RepeatDay" syncable="YES">
+        <attribute name="weekday" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
+        <relationship name="alarm" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Alarm" inverseName="repeatDays" inverseEntity="Alarm"/>
+    </entity>
+</model>

--- a/Clock/Clock/Data/Model/RepeatDayEntity.swift
+++ b/Clock/Clock/Data/Model/RepeatDayEntity.swift
@@ -1,0 +1,14 @@
+//
+//  RepeatDayEntity.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/21/25.
+//
+
+import CoreData
+
+@objc(RepeatDay)
+public class RepeatDayEntity: NSManagedObject {
+    @NSManaged public var weekday: Int16
+    @NSManaged public var alarm: AlarmEntity?
+}

--- a/Clock/Clock/Data/Persistence/CoreDataAlarmStorage.swift
+++ b/Clock/Clock/Data/Persistence/CoreDataAlarmStorage.swift
@@ -1,0 +1,58 @@
+//
+//  CoreDataAlarmStorage.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/21/25.
+//
+
+import CoreData
+
+final class CoreDataAlarmStorage: AlarmStorage {
+    private let container: NSPersistentContainer
+
+    init() {
+        container = NSPersistentContainer(name: "AlarmModel")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("CoreData Error: \(error)")
+            }
+        }
+    }
+
+    func fetchAlarmGroups<DomainEntity>(
+        _ mapped: @escaping (AlarmGroupEntity) -> DomainEntity,
+    ) async -> Result<[DomainEntity], CoreDataError> {
+        await withCheckedContinuation { continuation in
+            container.performBackgroundTask { context in
+                let request = AlarmGroupEntity.fetchRequest()
+                do {
+                    guard let entities = try context.fetch(request) as? [AlarmGroupEntity] else {
+                        continuation.resume(returning: .failure(.fetchFailed("Type Casting Failed")))
+                        return
+                    }
+                    let mapped = entities.map(mapped)
+                    continuation.resume(returning: .success(mapped))
+                } catch {
+                    continuation.resume(returning: .failure(.fetchFailed(error.localizedDescription)))
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    func insertAlarmGroup(
+        _ mapped: @escaping (NSManagedObjectContext) -> AlarmGroupEntity,
+    ) async -> Result<Void, CoreDataError> {
+        await withCheckedContinuation { continuation in
+            container.performBackgroundTask { context in
+                _ = mapped(context)
+                do {
+                    try context.save()
+                    continuation.resume(returning: .success(()))
+                } catch {
+                    continuation.resume(returning: .failure(.insertFailed(error.localizedDescription)))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Features

- [x] CoreData 스키마 정의(Entity)
- [x] CoreDataError 정의
- [x] AlarmGroupEntity에 대한 CRUD 구현

### Notes

- Alarm, RepeatDay, Timer CRUD까지 포함되면 코드양이 많아질 것 같아서, 중간 점검 차원으로 PR 작성합니다

### 확인 코드

```swift
//
//  DefaultAlarmRepository.swift
//  Clock
//
//  Created by youseokhwan on 5/21/25.
//

import Foundation

final class DefaultAlarmRepository {
    private let storage = CoreDataAlarmStorage()

    func fetchAlarmGroups() async -> Result<[AlarmGroup], CoreDataError> {
        await storage.fetchAlarmGroups { [weak self] entity in
            guard let self else { fatalError() }
            return toDomainAlarmGroup(entity)
        }
    }

    @discardableResult
    func dummyInsert() async -> Result<Void, CoreDataError> {
        let mockAlarmGroup = AlarmGroup(id: UUID(uuidString: "055FCAE4-9A45-482C-9DE3-0140B421F72F")!, name: "two", order: 1, alarms: [])

        return await storage.insertAlarmGroup { context in
            let entity = AlarmGroupEntity(context: context)
            entity.id = mockAlarmGroup.id
            entity.name = mockAlarmGroup.name
            entity.order = Int16(mockAlarmGroup.order)
            return entity
        }
    }

    @discardableResult
    func dummyUpdate() async -> Result<Void, CoreDataError> {
        let updated = AlarmGroup(
            id: UUID(uuidString: "055FCAE4-9A45-482C-9DE3-0140B421F72F")!,
            name: "수정된two",
            order: 1,
            alarms: []
        )

        return await storage.updateAlarmGroup(
            predicate: NSPredicate(format: "id == %@", updated.id as CVarArg),
        ) { context, original in
            original.name = updated.name
            original.order = Int16(updated.order)
            return original
        }
    }

    @discardableResult
    func dummyDelete() async -> Result<Void, CoreDataError> {
        await storage.deleteAlarmGroup(by: UUID(uuidString: "055FCAE4-9A45-482C-9DE3-0140B421F72F")!)
    }
}

extension DefaultAlarmRepository {
    func toDomainRepeatDays(_ entities: Set<RepeatDayEntity>?) -> [RepeatDay] {
        (entities ?? []).map {
            RepeatDay(weekday: Int($0.weekday))
        }
    }

    func toDomainAlarms(_ entities: Set<AlarmEntity>?) -> [Alarm] {
        (entities ?? []).map {
            Alarm(
                id: $0.id,
                hour: Int($0.hour),
                minute: Int($0.minute),
                label: $0.label,
                sound: .bell, // 임시
                isSnooze: $0.isSnooze,
                isEnabled: $0.isEnabled,
                repeatDays: toDomainRepeatDays($0.repeatDays),
            )
        }
    }

    func toDomainAlarmGroup(_ entity: AlarmGroupEntity) -> AlarmGroup {
        AlarmGroup(
            id: entity.id,
            name: entity.name,
            order: Int(entity.order),
            alarms: toDomainAlarms(entity.alarms),
        )
    }
}
```

```swift
enum DomainError: Error {

}
```

```swift
//
//  ViewController.swift
//  Clock
//
//  Created by youseokhwan on 5/20/25.
//

import UIKit

final class ViewController: UIViewController {
    override func viewDidLoad() {
        super.viewDidLoad()

        Task {
            let repository = DefaultAlarmRepository()

//            await repository.dummyInsert()
//            await repository.dummyUpdate()
//            await repository.dummyDelete()

            if let groups = try? await repository.fetchAlarmGroups().get() {
                for group in groups {
                    print(group.id, group.name)
                }
            }
        }
    }
}
```