### PR TITLE
[Feat] CoreData AlarmEntity CRUD 구현, Repository 구현

### DIFF
--- a/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
+++ b/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
@@ -17,7 +17,7 @@ protocol AlarmStorage {
         _ mapped: @escaping (NSManagedObjectContext) -> AlarmGroupEntity
     ) async -> Result<Void, CoreDataError>
     func updateAlarmGroup(
-        predicate: NSPredicate,
+        by id: UUID,
         _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmGroupEntity
     ) async -> Result<Void, CoreDataError>
     func deleteAlarmGroup(by id: UUID) async -> Result<Void, CoreDataError>
@@ -25,11 +25,11 @@ protocol AlarmStorage {
     // MARK: - AlarmEntity
 
     func insertAlarm(
-        groupID: UUID,
+        into groupID: UUID,
         _ mapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmEntity
     ) async -> Result<Void, CoreDataError>
     func updateAlarm(
-        predicate: NSPredicate,
+        by id: UUID,
         _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmEntity) -> AlarmEntity
     ) async -> Result<Void, CoreDataError>
     func deleteAlarm(by id: UUID) async -> Result<Void, CoreDataError>

--- a/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
+++ b/Clock/Clock/Data/Interface/Persistence/AlarmStorage.swift
@@ -8,6 +8,8 @@
 import CoreData
 
 protocol AlarmStorage {
+    // MARK: - AlarmGroupEntity
+
     func fetchAlarmGroups<DomainEntity>(
         _ mapped: @escaping (AlarmGroupEntity) -> DomainEntity
     ) async -> Result<[DomainEntity], CoreDataError>
@@ -19,4 +21,16 @@ protocol AlarmStorage {
         _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmGroupEntity
     ) async -> Result<Void, CoreDataError>
     func deleteAlarmGroup(by id: UUID) async -> Result<Void, CoreDataError>
+
+    // MARK: - AlarmEntity
+
+    func insertAlarm(
+        groupID: UUID,
+        _ mapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmEntity
+    ) async -> Result<Void, CoreDataError>
+    func updateAlarm(
+        predicate: NSPredicate,
+        _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmEntity) -> AlarmEntity
+    ) async -> Result<Void, CoreDataError>
+    func deleteAlarm(by id: UUID) async -> Result<Void, CoreDataError>
 }

--- a/Clock/Clock/Data/Model/AlarmModel.xcdatamodeld/AlarmModel.xcdatamodel/contents
+++ b/Clock/Clock/Data/Model/AlarmModel.xcdatamodeld/AlarmModel.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Alarm" representedClassName="Alarm" syncable="YES">
         <attribute name="hour" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="isEnable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isSnooze" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="label" attributeType="String" defaultValueString=""/>
         <attribute name="minute" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Clock/Clock/Data/Persistence/CoreDataAlarmStorage.swift
+++ b/Clock/Clock/Data/Persistence/CoreDataAlarmStorage.swift
@@ -62,13 +62,13 @@ final class CoreDataAlarmStorage: AlarmStorage {
 
     @discardableResult
     func updateAlarmGroup(
-        predicate: NSPredicate,
+        by id: UUID,
         _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmGroupEntity,
     ) async -> Result<Void, CoreDataError> {
         await withCheckedContinuation { continuation in
             container.performBackgroundTask { context in
                 let request = AlarmGroupEntity.fetchRequest()
-                request.predicate = predicate
+                request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
 
                 do {
                     guard let original = try context.fetch(request).first as? AlarmGroupEntity else {
@@ -113,7 +113,7 @@ final class CoreDataAlarmStorage: AlarmStorage {
 
     @discardableResult
     func insertAlarm(
-        groupID: UUID,
+        into groupID: UUID,
         _ mapped: @escaping (NSManagedObjectContext, AlarmGroupEntity) -> AlarmEntity
     ) async -> Result<Void, CoreDataError> {
         await withCheckedContinuation { continuation in
@@ -139,13 +139,13 @@ final class CoreDataAlarmStorage: AlarmStorage {
 
     @discardableResult
     func updateAlarm(
-        predicate: NSPredicate,
+        by id: UUID,
         _ updatedAndMapped: @escaping (NSManagedObjectContext, AlarmEntity) -> AlarmEntity,
     ) async -> Result<Void, CoreDataError> {
         await withCheckedContinuation { continuation in
             container.performBackgroundTask { context in
                 let request = AlarmEntity.fetchRequest()
-                request.predicate = predicate
+                request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
 
                 do {
                     guard let original = try context.fetch(request).first as? AlarmEntity else {

--- a/Clock/Clock/Data/Repository/DefaultAlarmGroupRepository.swift
+++ b/Clock/Clock/Data/Repository/DefaultAlarmGroupRepository.swift
@@ -1,0 +1,108 @@
+//
+//  DefaultAlarmGroupRepository.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/23/25.
+//
+
+import Foundation
+
+final class DefaultAlarmGroupRepository: AlarmGroupRepository {
+    private let storage: AlarmStorage
+
+    init(storage: AlarmStorage) {
+        self.storage = storage
+    }
+
+    func fetchAll() async -> Result<[AlarmGroup], Error> {
+        let result = await storage.fetchAlarmGroups { [weak self] entity in
+            guard let self else { fatalError("deallocated") }
+            return toDomainAlarmGroup(entity)
+        }
+
+        switch result {
+        case .success(let entities):
+            return .success(entities)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    @discardableResult
+    func create(_ alarmGroup: AlarmGroup) async -> Result<Void, Error> {
+        let result = await storage.insertAlarmGroup { context in
+            let entity = AlarmGroupEntity(context: context)
+            entity.id = alarmGroup.id
+            entity.name = alarmGroup.name
+            entity.order = Int16(alarmGroup.order)
+            return entity
+        }
+
+        switch result {
+        case .success:
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    @discardableResult
+    func update(_ alarmGroup: AlarmGroup) async -> Result<Void, Error> {
+        let result = await storage.updateAlarmGroup(by: alarmGroup.id) { context, entity in
+            entity.name = alarmGroup.name
+            entity.order = Int16(alarmGroup.order)
+            return entity
+        }
+
+        switch result {
+        case .success:
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    @discardableResult
+    func delete(by id: UUID) async -> Result<Void, Error> {
+        let result = await storage.deleteAlarmGroup(by: id)
+
+        switch result {
+        case .success:
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}
+
+private extension DefaultAlarmGroupRepository {
+    func toDomainAlarmGroup(_ entity: AlarmGroupEntity) -> AlarmGroup {
+        AlarmGroup(
+            id: entity.id,
+            name: entity.name,
+            order: Int(entity.order),
+            alarms: toDomainAlarms(entity.alarms),
+        )
+    }
+
+    func toDomainAlarms(_ entities: Set<AlarmEntity>?) -> [Alarm] {
+        (entities ?? []).map {
+            Alarm(
+                id: $0.id,
+                hour: Int($0.hour),
+                minute: Int($0.minute),
+                label: $0.label,
+                sound: .bell, // TODO: 임시로 bell 삽입
+                isSnooze: $0.isSnooze,
+                isEnabled: $0.isEnabled,
+                repeatDays: toDomainRepeatDays($0.repeatDays),
+            )
+        }
+    }
+
+    func toDomainRepeatDays(_ entities: Set<RepeatDayEntity>?) -> [RepeatDay] {
+        (entities ?? []).map {
+            RepeatDay(weekday: Int($0.weekday))
+        }
+    }
+}

--- a/Clock/Clock/Data/Repository/DefaultAlarmRepository.swift
+++ b/Clock/Clock/Data/Repository/DefaultAlarmRepository.swift
@@ -1,0 +1,89 @@
+//
+//  DefaultAlarmRepository.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/23/25.
+//
+
+import Foundation
+
+final class DefaultAlarmRepository: AlarmRepository {
+    private let storage: AlarmStorage
+
+    init(storage: AlarmStorage) {
+        self.storage = storage
+    }
+
+    @discardableResult
+    func create(_ alarm: Alarm, into groupID: UUID) async -> Result<Void, Error> {
+        let result = await storage.insertAlarm(into: groupID) { context, groupEntity in
+            let alarmEntity = AlarmEntity(context: context)
+            alarmEntity.id = alarm.id
+            alarmEntity.hour = Int16(alarm.hour)
+            alarmEntity.minute = Int16(alarm.minute)
+            alarmEntity.label = alarm.label
+            alarmEntity.sound = alarm.sound.path
+            alarmEntity.isSnooze = alarm.isSnooze
+            alarmEntity.isEnabled = alarm.isEnabled
+            for repeatDay in alarm.repeatDays {
+                let repeatDayEntity = RepeatDayEntity(context: context)
+                repeatDayEntity.weekday = Int16(repeatDay.weekday)
+                repeatDayEntity.alarm = alarmEntity
+                alarmEntity.repeatDays?.insert(repeatDayEntity)
+            }
+            alarmEntity.alarmGroup = groupEntity
+            return alarmEntity
+        }
+
+        switch result {
+        case .success:
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    @discardableResult
+    func update(_ alarm: Alarm) async -> Result<Void, Error> {
+        let result = await storage.updateAlarm(by: alarm.id) { context, entity in
+            entity.id = alarm.id
+            entity.hour = Int16(alarm.hour)
+            entity.minute = Int16(alarm.minute)
+            entity.label = alarm.label
+            entity.sound = alarm.sound.path
+            entity.isSnooze = alarm.isSnooze
+            entity.isEnabled = alarm.isEnabled
+            if let repeatDaysEntities = entity.repeatDays {
+                for repeatDayEntity in repeatDaysEntities {
+                    context.delete(repeatDayEntity)
+                }
+            }
+            for repeatDay in alarm.repeatDays {
+                let repeatDayEntity = RepeatDayEntity(context: context)
+                repeatDayEntity.weekday = Int16(repeatDay.weekday)
+                repeatDayEntity.alarm = entity
+                entity.repeatDays?.insert(repeatDayEntity)
+            }
+            return entity
+        }
+
+        switch result {
+        case .success:
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    @discardableResult
+    func delete(by id: UUID) async -> Result<Void, Error> {
+        let result = await storage.deleteAlarm(by: id)
+
+        switch result {
+        case .success:
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/Clock/Clock/Domain/Interface/Repository/AlarmGroupRepository.swift
+++ b/Clock/Clock/Domain/Interface/Repository/AlarmGroupRepository.swift
@@ -1,0 +1,15 @@
+//
+//  AlarmGroupRepository.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/23/25.
+//
+
+import Foundation
+
+protocol AlarmGroupRepository {
+    func fetchAll() async -> Result<[AlarmGroup], Error>
+    func create(_ alarmGroup: AlarmGroup) async -> Result<Void, Error>
+    func update(_ alarmGroup: AlarmGroup) async -> Result<Void, Error>
+    func delete(by id: UUID) async -> Result<Void, Error>
+}

--- a/Clock/Clock/Domain/Interface/Repository/AlarmRepository.swift
+++ b/Clock/Clock/Domain/Interface/Repository/AlarmRepository.swift
@@ -1,0 +1,14 @@
+//
+//  AlarmRepository.swift
+//  Clock
+//
+//  Created by youseokhwan on 5/23/25.
+//
+
+import Foundation
+
+protocol AlarmRepository {
+    func create(_ alarm: Alarm, into groupID: UUID) async -> Result<Void, Error>
+    func update(_ alarm: Alarm) async -> Result<Void, Error>
+    func delete(by id: UUID) async -> Result<Void, Error>
+}


### PR DESCRIPTION
### Features

* 기존에 Repository에서 NSPredicate를 파라미터로 던지는 부분이 있었는데, UUID를 던지도록 변경하여 직관적으로 개선했습니다.
* AlarmEntity에 대한 CRUD 구현했습니다. (fetch는 AlarmGroupEntity에서 진행하기 때문에 없습니다.)
* AlarmGroupRepository, AlarmRepository에 대한 프로토콜과 구현체 구현하였습니다.