### PR TITLE
refactor: 바 버튼 아이템 팩토리 메서드 수정

### DIFF
--- a/Clock/Clock/Presentation/Factory/BarButtonFactory.swift
+++ b/Clock/Clock/Presentation/Factory/BarButtonFactory.swift
@@ -1,20 +1,15 @@
 import UIKit
 
 enum BarButtonFactory {
-    static func editButton() -> UIBarButtonItem {
-        let item = UIBarButtonItem(title: "편집", style: .plain, target: nil, action: nil)
+    static func customButton(with title: String) -> UIBarButtonItem {
+        let item = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
         item.tintColor = .systemOrange
-        item.setTitleTextAttributes([
-            .font: UIFont.boldSystemFont(ofSize: 17)
-        ], for: .normal)
 
         return item
     }
 
     static func plusButton() -> UIBarButtonItem {
-        let config = UIImage.SymbolConfiguration(weight: .bold)
-        let image = UIImage(systemName: "plus", withConfiguration: config)
-        let item = UIBarButtonItem(image: image, style: .plain, target: nil, action: nil)
+        let item = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
         item.tintColor = .systemOrange
 
         return item

--- a/Clock/Clock/Presentation/Scene/Alarm/ViewController/AlarmViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Alarm/ViewController/AlarmViewController.swift
@@ -7,7 +7,7 @@ final class AlarmViewController: UIViewController {
 
     private let disposeBag = DisposeBag()
 
-    private let editButton = BarButtonFactory.editButton()
+    private let editButton = BarButtonFactory.customButton(with: "편집")
     private let plusButton = BarButtonFactory.plusButton()
     private let alarmTableView = AlarmTableView(frame: .zero, style: .grouped)
     private var dataSource: UITableViewDiffableDataSource<AlarmSection, AlarmDisplay>!

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
@@ -40,7 +40,7 @@ final class TimerViewController: UIViewController {
 
 private extension TimerViewController {
     func setNavigationBar() {
-        let editButton = BarButtonFactory.editButton()
+        let editButton = BarButtonFactory.customButton(with: "편집")
         let plusButton = BarButtonFactory.plusButton()
         self.navigationItem.setLeftBarButton(editButton, animated: true)
         self.navigationItem.setRightBarButton(plusButton, animated: true)


### PR DESCRIPTION
기존에 `편집` 버튼을 생성하던 팩토리 메서드를 title을 입력받아 범용적으로 사용할 수 있도록 수정하였습니다.
타이머 화면에서는 `취소`, `설정` 버튼을 생성하는데 사용할 수 있을 것 같습니다.

FYI:
처음에 팩토리 메서드를 구현할 때는 텍스트가 볼드체인줄 알고 볼드 처리를 했었는데요.
(시뮬레이터랑 아이폰 화면을 육안으로 비교해보니 그런 줄 알았습니다..)
실기기에 빌드해서 확인해보니 볼드체가 아니었네요..
해당 부분도 같이 수정했습니다.

기존과 다르게 사실상 설정이 `title`과 `tintColor` 밖에 없기 때문에 결과적으로는 팩토리 메서드가 필요가 없긴 합니다.