### PR TITLE
Feat: 타이머 로직 구현

### DIFF
--- a/Clock/Clock/Domain/Model/Timer.swift
+++ b/Clock/Clock/Domain/Model/Timer.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Timer {
     let id: UUID
     let milliseconds: Int
+    let isRunning: Bool
     let currentMilliseconds: Int
     let sound: Sound
     let label: String?

--- a/Clock/Clock/Presentation/Extension/UIPickerView+extension.swift
+++ b/Clock/Clock/Presentation/Extension/UIPickerView+extension.swift
@@ -13,15 +13,17 @@ extension UIPickerView {
         let fontSize: CGFloat = 20
         let pickerWidth: CGFloat = self.frame.width
         let labelY: CGFloat = (self.frame.size.height / 2) - fontSize + 2
+        let padding: CGFloat = 16
 
         for i in 0..<count {
             let label = UILabel()
             label.text = labels[i]
             label.textColor = .white
+            label.textAlignment = .center
             label.font = .systemFont(ofSize: fontSize, weight: .bold)
 
-            let labelX: CGFloat = (pickerWidth / CGFloat(count)) * CGFloat(i + 1) - fontSize * 1.5
-
+            var labelX: CGFloat = (pickerWidth / CGFloat(count)) * CGFloat(i + 1) - padding
+            if i == 0 { labelX -= padding }
             label.frame = CGRect(
                 x: labelX,
                 y: labelY,

--- a/Clock/Clock/Presentation/Model/TimerDisplay.swift
+++ b/Clock/Clock/Presentation/Model/TimerDisplay.swift
@@ -16,7 +16,8 @@ struct TimerDisplay {
     let sound: Sound
 
     mutating func reduceRemaining() {
-        remainingMillisecond -= 1000
+        guard isRunning else { return }
+        remainingMillisecond = max(0, remainingMillisecond - 1000)
         remainingTimeString = TimerDisplayFormatter.formatToDigitalTime(millisecond: remainingMillisecond)
     }
 

--- a/Clock/Clock/Presentation/Model/TimerDisplay.swift
+++ b/Clock/Clock/Presentation/Model/TimerDisplay.swift
@@ -19,8 +19,12 @@ struct TimerDisplay {
         remainingTimeString = TimerDisplayFormatter.formatToDigitalTime(millisecond: remainingMillisecond)
     }
 
-    mutating func isRunnigToggle() {
+    mutating func toggleRunningState() {
         isRunning.toggle()
+    }
+
+    mutating func setRunningState(_ state: Bool) {
+        isRunning = state
     }
 }
 

--- a/Clock/Clock/Presentation/Model/TimerDisplay.swift
+++ b/Clock/Clock/Presentation/Model/TimerDisplay.swift
@@ -13,6 +13,7 @@ struct TimerDisplay {
     var remainingMillisecond: Int
     var remainingTimeString: String
     var isRunning: Bool
+    let sound: Sound
 
     mutating func reduceRemaining() {
         remainingMillisecond -= 1000
@@ -21,10 +22,6 @@ struct TimerDisplay {
 
     mutating func toggleRunningState() {
         isRunning.toggle()
-    }
-
-    mutating func setRunningState(_ state: Bool) {
-        isRunning = state
     }
 }
 

--- a/Clock/Clock/Presentation/Model/TimerDisplay.swift
+++ b/Clock/Clock/Presentation/Model/TimerDisplay.swift
@@ -10,7 +10,18 @@ import Foundation
 struct TimerDisplay {
     let id: UUID
     let label: String
-    let currentTime: String
+    var remainingMillisecond: Int
+    var remainingTimeString: String
+    var isRunning: Bool
+
+    mutating func reduceRemaining() {
+        remainingMillisecond -= 1000
+        remainingTimeString = TimerDisplayFormatter.formatToDigitalTime(millisecond: remainingMillisecond)
+    }
+
+    mutating func isRunnigToggle() {
+        isRunning.toggle()
+    }
 }
 
 enum TimerDisplayFormatter {

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/Subview/Cell/OngoingTimerCell.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/Subview/Cell/OngoingTimerCell.swift
@@ -6,9 +6,12 @@
 //
 
 import UIKit
+import RxSwift
 
 final class OngoingTimerCell: UITableViewCell, ReuseIdentifier {
-    private let currentTimerLabel: UILabel = {
+    private(set) var disposeBag = DisposeBag()
+
+    private let remainingTimerLabel: UILabel = {
         let label = UILabel()
         label.text = "10:00"
         label.textColor = .white
@@ -43,9 +46,16 @@ final class OngoingTimerCell: UITableViewCell, ReuseIdentifier {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        disposeBag = DisposeBag()
+    }
+
     func configure(timer: TimerDisplay) {
-        currentTimerLabel.text = timer.currentTime
+        remainingTimerLabel.text = timer.remainingTimeString
         labelLabel.text = timer.label
+        controlButton.isSelected = timer.isRunning
     }
 }
 
@@ -57,21 +67,21 @@ private extension OngoingTimerCell {
 
     func setHierarchy() {
         [
-            currentTimerLabel,
+            remainingTimerLabel,
             labelLabel,
             controlButton
         ].forEach { self.contentView.addSubview($0) }
     }
 
     func setConstraints() {
-        currentTimerLabel.snp.makeConstraints { make in
+        remainingTimerLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(16)
             make.leading.equalToSuperview().inset(12)
         }
 
         labelLabel.snp.makeConstraints { make in
-            make.top.equalTo(currentTimerLabel.snp.bottom).offset(12)
-            make.leading.equalTo(currentTimerLabel)
+            make.top.equalTo(remainingTimerLabel.snp.bottom).offset(12)
+            make.leading.equalTo(remainingTimerLabel)
             make.bottom.equalToSuperview().inset(12)
         }
 

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/Subview/Cell/RecentTimerCell.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/Subview/Cell/RecentTimerCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class RecentTimerCell: UITableViewCell, ReuseIdentifier {
-    private let currentTimerLabel: UILabel = {
+    private let remainingTimerLabel: UILabel = {
         let label = UILabel()
         label.text = "10:00"
         label.textColor = .white
@@ -44,7 +44,7 @@ final class RecentTimerCell: UITableViewCell, ReuseIdentifier {
     }
 
     func configure(timer: TimerDisplay) {
-        currentTimerLabel.text = timer.currentTime
+        remainingTimerLabel.text = timer.remainingTimeString
         labelLabel.text = timer.label
     }
 }
@@ -57,21 +57,21 @@ private extension RecentTimerCell {
 
     func setHierarchy() {
         [
-            currentTimerLabel,
+            remainingTimerLabel,
             labelLabel,
             controlButton
         ].forEach { self.contentView.addSubview($0) }
     }
 
     func setConstraints() {
-        currentTimerLabel.snp.makeConstraints { make in
+        remainingTimerLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(16)
             make.leading.equalToSuperview().inset(12)
         }
 
         labelLabel.snp.makeConstraints { make in
-            make.top.equalTo(currentTimerLabel.snp.bottom).offset(12)
-            make.leading.equalTo(currentTimerLabel)
+            make.top.equalTo(remainingTimerLabel.snp.bottom).offset(12)
+            make.leading.equalTo(remainingTimerLabel)
             make.bottom.equalToSuperview().inset(12)
         }
 

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/Subview/Cell/RecentTimerCell.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/Subview/Cell/RecentTimerCell.swift
@@ -6,8 +6,11 @@
 //
 
 import UIKit
+import RxSwift
 
 final class RecentTimerCell: UITableViewCell, ReuseIdentifier {
+    private(set) var disposeBag = DisposeBag()
+
     private let remainingTimerLabel: UILabel = {
         let label = UILabel()
         label.text = "10:00"
@@ -41,6 +44,12 @@ final class RecentTimerCell: UITableViewCell, ReuseIdentifier {
     required
     init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        disposeBag = DisposeBag()
     }
 
     func configure(timer: TimerDisplay) {

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
@@ -99,7 +99,13 @@ extension TimerViewController: UITableViewDataSource {
             ) as? OngoingTimerCell else {
                 return UITableViewCell()
             }
-            cell.configure(timer: viewModel.ongoingTimer.value[indexPath.row])
+            let data = viewModel.ongoingTimer.value[indexPath.row]
+            cell.configure(timer: data)
+            cell.controlButton.rx.tap
+                .withLatestFrom(Observable.just(data.id))
+                .bind(to: viewModel.startTimer)
+                .disposed(by: cell.disposeBag)
+
             return cell
         case .recentTimer:
             guard let cell = tableView.dequeueReusableCell(

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
@@ -103,7 +103,7 @@ extension TimerViewController: UITableViewDataSource {
             cell.configure(timer: data)
             cell.controlButton.rx.tap
                 .withLatestFrom(Observable.just(data.id))
-                .bind(to: viewModel.handleTimerSelection)
+                .bind(to: viewModel.toggleOrAddTimer)
                 .disposed(by: cell.disposeBag)
 
             return cell
@@ -117,7 +117,7 @@ extension TimerViewController: UITableViewDataSource {
             cell.configure(timer: data)
             cell.controlButton.rx.tap
                 .withLatestFrom(Observable.just(data.id))
-                .bind(to: viewModel.handleTimerSelection)
+                .bind(to: viewModel.toggleOrAddTimer)
                 .disposed(by: cell.disposeBag)
             return cell
         default:

--- a/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewController/TimerViewController.swift
@@ -103,7 +103,7 @@ extension TimerViewController: UITableViewDataSource {
             cell.configure(timer: data)
             cell.controlButton.rx.tap
                 .withLatestFrom(Observable.just(data.id))
-                .bind(to: viewModel.startTimer)
+                .bind(to: viewModel.handleTimerSelection)
                 .disposed(by: cell.disposeBag)
 
             return cell
@@ -113,7 +113,12 @@ extension TimerViewController: UITableViewDataSource {
             ) as? RecentTimerCell else {
                 return UITableViewCell()
             }
-            cell.configure(timer: viewModel.recentTimer.value[indexPath.row])
+            let data = viewModel.recentTimer.value[indexPath.row]
+            cell.configure(timer: data)
+            cell.controlButton.rx.tap
+                .withLatestFrom(Observable.just(data.id))
+                .bind(to: viewModel.handleTimerSelection)
+                .disposed(by: cell.disposeBag)
             return cell
         default:
             return UITableViewCell()

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/DefaultTimerViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/DefaultTimerViewModel.swift
@@ -136,13 +136,21 @@ final class DefaultTimerViewModel: TimerViewModel {
             return
         }
 
-        guard var recent = recentTimer.value.first(where: {$0.id == id}) else {
+        guard let recent = recentTimer.value.first(where: {$0.id == id}) else {
             return
         }
 
+        let timer = Timer(
+            id: UUID(),
+            milliseconds: recent.remainingMillisecond,
+            isRunning: true,
+            currentMilliseconds: recent.remainingMillisecond,
+            sound: recent.sound,
+            label: recent.label
+        )
+        let timerDisplay = toTimerDisplay(timer: timer)
         //TODO: Core Data에 ongoinTimer 추가
-        recent.setRunningState(true)
-        var updatedOngoing = ongoingTimer.value + [recent]
+        var updatedOngoing = ongoingTimer.value + [timerDisplay]
         updatedOngoing.sort { $0.remainingMillisecond < $1.remainingMillisecond }
         ongoingTimer.accept(updatedOngoing)
         return
@@ -158,7 +166,8 @@ final class DefaultTimerViewModel: TimerViewModel {
             remainingTimeString: TimerDisplayFormatter.formatToDigitalTime(
                 millisecond: timer.currentMilliseconds
             ),
-            isRunning: timer.isRunning
+            isRunning: timer.isRunning,
+            sound: timer.sound
         )
     }
 }

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/DefaultTimerViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/DefaultTimerViewModel.swift
@@ -67,11 +67,10 @@ final class DefaultTimerViewModel: TimerViewModel {
     private func updateTimersByTick() {
         var updatedTimers = ongoingTimer.value
         for (index, timer) in ongoingTimer.value.enumerated() where timer.isRunning {
-            let newTime = max(0, timer.remainingMillisecond - 1000)
             var updated = timer
             updated.reduceRemaining()
             updatedTimers[index] = updated
-            if newTime == 0 {
+            if updated.remainingMillisecond == 0 {
                 //TODO: 사운드 재생, coreData 저장
                 updatedTimers.remove(at: index)
                 print("사운드 재생: \(timer.id)")

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerViewModel.swift
@@ -7,13 +7,14 @@
 
 import Foundation
 import RxSwift
-import RxCocoa
+import RxRelay
 
 protocol TimerViewModel: TimerViewModelInput, TimerViewModelOutput { }
 
 protocol TimerViewModelInput {
     var viewDidLoad: PublishRelay<Void> { get }
     var createTimer: PublishRelay<(time: Int, label: String, sound: Sound)> { get }
+    var startTimer: PublishRelay<UUID> { get }
 }
 
 protocol TimerViewModelOutput {

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerViewModel.swift
@@ -14,7 +14,7 @@ protocol TimerViewModel: TimerViewModelInput, TimerViewModelOutput { }
 protocol TimerViewModelInput {
     var viewDidLoad: PublishRelay<Void> { get }
     var createTimer: PublishRelay<(time: Int, label: String, sound: Sound)> { get }
-    var handleTimerSelection: PublishRelay<UUID> { get }
+    var toggleOrAddTimer: PublishRelay<UUID> { get }
 }
 
 protocol TimerViewModelOutput {

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerViewModel.swift
@@ -14,7 +14,7 @@ protocol TimerViewModel: TimerViewModelInput, TimerViewModelOutput { }
 protocol TimerViewModelInput {
     var viewDidLoad: PublishRelay<Void> { get }
     var createTimer: PublishRelay<(time: Int, label: String, sound: Sound)> { get }
-    var startTimer: PublishRelay<UUID> { get }
+    var handleTimerSelection: PublishRelay<UUID> { get }
 }
 
 protocol TimerViewModelOutput {


### PR DESCRIPTION
## Feature
- [x]  UIPicker 라벨 위치 조정
- [x] 타이머 생성, 중단, 재개 로직 구현
- [x] 동시 타이머 동작 로직 구현

## UIPicker 라벨 
<table>
  <tr>
    <td colspan="1" style="text-align: center; font-weight: bold;">
16 pro
    </td>
    <td colspan="1" style="text-align: center; font-weight: bold;">
13 mini
    </td>
    <td colspan="1" style="text-align: center; font-weight: bold;">
se
    </td>
  </tr>
  <tr>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/4de10dd9-313f-41a9-95db-47e020322121" width="300"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/6138b7a1-57b0-4214-b381-6b84895d2641" width="300"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/1b32a4f7-76b9-4eb7-8ac9-2d9640000a7e" width="300"/></td>
  </tr>
</table>


## 시연영상
<table>
  <tr>
    <td colspan="1" style="text-align: center; font-weight: bold;">
동시 타이머 중단, 재개
    </td>
  </tr>
  <tr>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/410ad8bb-9bad-4d5d-a032-448c99c8d1d0" width="300"/></td>
  </tr>
</table>

## 기타 참고 사항
 ### 동시 타이머 로직

1. ViewModel 프로퍼티로 1초마다 Observable을 방출하는 객체 생성 (globalTick)
2. 옵저버블을 방출할 떄마다 실행 중인 타이머를 업데이트하는 메서드 호출 (updateTimersByTick)
3. ongoingTimer 중 isRunning == true인 타이머 (실제 동작 중인 타이머)를 1초씩 감소
    1. 만약 0초가 된다면 사운드 재생 및, ongoingTimer에서 제거, CoreData에 저장
- [ ]  사운드 재생
- [ ]  CoreData 저장

### 타이머 생성 로직

1. VC로부터, time, label, sound를 받아서 Timer 객체 생성 후 CoreData에 저장
2. 생성한 Timer 객체를 ongoingTimer에 추가 (isRunning = true)
- [ ]  CoreData 저장
- [ ]  ongoingTimer에 추가
- [x]  최근 항목에서 ongoingTimer에 추가

### 타이머 중지, 재개 로직, 최근 항목에서 타이머 생성

1. VC로부터 Timer ID를 전달 받음
2. VM에서 OngoingTimer에 전달 받은 Timer ID가 존재하면, isRunning Toggle
3. 존재하지 않다면, RecentTimer에서 Timer ID가 동일한 ID를 찾음
    1. 해당 Timer의 정보를 Ongoing Timer에 추가 후 CoreData에 저장
    2. Or 타이머 생성 로직의 파라미터로 Timer를 넘겨주는 메서드 생성
- [ ]  CoreData 저장

### Core Data에 타이머의 남은 시간 저장은 VM이 deinit 될 때 전체적으로 업데이트 필요

- 1초마다 CoreData 남은 시간을 업데이트 할 필요가 없을 거 같음
- ongoing Timer의 생성, 삭제는 바로 Core Data에 저장하되, 남은 시간을 업데이트 하는 것은 VM의 deinit 시 CoreData 업데이트

### updateTimersByTick 메서드 개선 필요
1. `updatedTimers.remove(at: index)` 를 루프 안에서 호출하면서 `break` 처리하는 방식은 타이머가 여러 개 종료될 수도 있는데, 한 번만 처리함.

### Ongoing → Active로 통일 필요



## 확인 코드 
```swift
final class FetchOngoingTimerUseCase: FetchableOngoingTimerUseCase {
    func execute() async throws -> [Timer] {
        [
            Timer(
                id: UUID(),
                milliseconds: 1000000,
                isRunning: false,
                currentMilliseconds: 1000000,
                sound: .bell,
                label: nil
            ),
            Timer(
                id: UUID(),
                milliseconds: 11200000,
                isRunning: false,
                currentMilliseconds: 11200000,
                sound: .bell,
                label: "낮잠"
            ),
            Timer(
                id: UUID(),
                milliseconds: 112340,
                isRunning: true,
                currentMilliseconds: 112340,
                sound: .bell,
                label: nil
            ),
        ]
    }
}

```
```swift
final class FetchRecentTimerUseCase: FetchableRecentTimerUseCase {
    func execute() async throws -> [Timer] {
        [
            Timer(
                id: UUID(),
                milliseconds: 6000,
                isRunning: false,
                currentMilliseconds: 6000,
                sound: .bell,
                label: nil
            ),
            Timer(
                id: UUID(),
                milliseconds: 51200000,
                isRunning: true,
                currentMilliseconds: 51200000,
                sound: .bell,
                label: nil
            ),
        ]
    }
}
```