### PR TITLE
[Feat] Timer 동시 접근 문제 Actor로 개선

### DIFF
--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/DefaultTimerViewModel.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/DefaultTimerViewModel.swift
@@ -15,6 +15,9 @@ final class DefaultTimerViewModel: TimerViewModel {
     private let deleteTimerUseCase: DeletableTimerUseCase
     private let updateTimerUseCase: UpdatableTimerUseCase
 
+    private let ongoingTimerActor = TimerStateActor()
+    private let recentTimerActor = TimerStateActor()
+
     private let disposeBag = DisposeBag()
 
     private let globalTick = Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
@@ -27,7 +30,6 @@ final class DefaultTimerViewModel: TimerViewModel {
     let deleteTimer = PublishRelay<IndexPath>()
     let saveTimers = PublishRelay<Void>()
     let updatedSound = PublishRelay<SoundDisplay>()
-
 
     // Output
     let recentTimer = BehaviorRelay<[TimerDisplay]>(value: [])
@@ -88,22 +90,25 @@ final class DefaultTimerViewModel: TimerViewModel {
     }
 
     private func updateTimersByTick() {
-        var updatedTimers = ongoingTimer.value
-        for (index, timer) in ongoingTimer.value.enumerated() where timer.isRunning {
-            var updated = timer
-            updated.reduceRemaining()
-            updatedTimers[index] = updated
-            if updated.remainingMillisecond == 0 {
-                //TODO: 사운드 재생
-                let timer = updatedTimers.remove(at: index)
-                deleteTimerFromStorage(id: timer.id)
-                print("사운드 재생: \(timer.id)")
-                break
+        Task {
+            var updatedTimers = await ongoingTimerActor.get()
+            await ongoingTimerActor.update { timers in
+                for (index, timer) in timers.enumerated() where timer.isRunning {
+                    var updated = timer
+                    updated.reduceRemaining()
+                    updatedTimers[index] = updated
+                    if updated.remainingMillisecond == 0 {
+                        //TODO: 사운드 재생
+                        let timer = updatedTimers.remove(at: index)
+                        deleteTimerFromStorage(id: timer.id)
+                        print("사운드 재생: \(timer.id)")
+                        break
+                    }
+                }
+                return updatedTimers
             }
-        }
 
-        timerUpdateQueue.async {
-            self.ongoingTimer.accept(updatedTimers)
+            ongoingTimer.accept(await ongoingTimerActor.get())
         }
     }
 
@@ -111,8 +116,13 @@ final class DefaultTimerViewModel: TimerViewModel {
         Task {
             do {
                 let (ongoing, recent) = try await fetchAllTimerUseCase.execute()
-                updateSortedTimerDisplayRelay(with: ongoing.map{ TimerMapper.mapToDisplay(timer: $0) }, to: ongoingTimer)
-                updateSortedTimerDisplayRelay(with: recent.map{ TimerMapper.mapToDisplay(timer: $0) }, to: recentTimer)
+                let ongoingTimerDisplay = ongoing.map{ TimerMapper.mapToDisplay(timer: $0) }
+                let recentTimerDisplay = recent.map{ TimerMapper.mapToDisplay(timer: $0) }
+                await ongoingTimerActor.set(ongoingTimerDisplay)
+                await recentTimerActor.set(recentTimerDisplay)
+
+                ongoingTimer.accept(await ongoingTimerActor.get())
+                recentTimer.accept(await recentTimerActor.get())
             } catch {
                 self.error.accept(error)
             }
@@ -163,83 +173,72 @@ final class DefaultTimerViewModel: TimerViewModel {
                 _ = try await (ongoingResult, recentResult)
 
                 let ongoingDisplay = TimerMapper.mapToDisplay(timer: newOngoing)
-                updateSortedTimerDisplayRelay(with: ongoingTimer.value + [ongoingDisplay], to: ongoingTimer)
+                await ongoingTimerActor.update { timers in
+                    return timers + [ongoingDisplay]
+                }
+                ongoingTimer.accept(await ongoingTimerActor.get())
+
 
                 let recentDisplay = TimerMapper.mapToDisplay(timer: newRecent)
-                updateSortedTimerDisplayRelay(with: recentTimer.value + [recentDisplay], to: recentTimer)
+                await recentTimerActor.update { timers in
+                    return timers + [recentDisplay]
+                }
+                recentTimer.accept(await recentTimerActor.get())
             } catch {
                 self.error.accept(error)
             }
         }
     }
 
-    private func updateSortedTimerDisplayRelay(
-        with displays: [TimerDisplay],
-        to relay: BehaviorRelay<[TimerDisplay]>
-    ) {
-        let sorted = displays.sorted{ $0.remainingMillisecond < $1.remainingMillisecond }
-
-        timerUpdateQueue.async {
-            relay.accept(sorted)
-        }
-    }
-
     private func toggleOrAddTimer(with id: UUID) {
-        // ongoingTimer에 존재한다면 토글, 없으면 RecentTimer를 ongoingTimer에 추가
-        if let index = ongoingTimer.value.firstIndex(where: { $0.id == id }) {
-            var timerDisplays = ongoingTimer.value
-            var timerDisplay = timerDisplays[index]
-            timerDisplay.toggleRunningState()
-            timerDisplays[index] = timerDisplay
+        Task {
+            // ongoingTimer에 존재한다면 토글, 없으면 RecentTimer를 ongoingTimer에 추가
+            if let index = ongoingTimer.value.firstIndex(where: { $0.id == id }) {
+                await ongoingTimerActor.toggleRunnningState(at: index)
+                ongoingTimer.accept(await ongoingTimerActor.get())
 
-            updateSortedTimerDisplayRelay(with: timerDisplays, to: ongoingTimer)
+                let timer = TimerMapper.mapToModel(display: await ongoingTimerActor.get()[index])
+                updateTimerInStorage(timer: timer)
+                return
+            }
 
-            let timer = TimerMapper.mapToModel(display: timerDisplay)
-            updateTimerInStorage(timer: timer)
-            return
+            guard let recent = recentTimer.value.first(where: {$0.id == id}) else {
+                return
+            }
+
+            let timer = Timer(
+                id: UUID(),
+                milliseconds: recent.remainingMillisecond,
+                isRunning: true,
+                currentMilliseconds: recent.remainingMillisecond,
+                sound: recent.sound,
+                label: recent.label
+            )
+
+            let timerDisplay = TimerMapper.mapToDisplay(timer: timer)
+            await ongoingTimerActor.update { timers in
+                return timers + [timerDisplay]
+            }
+
+            ongoingTimer.accept(await ongoingTimerActor.get())
+            createTimerInStorage(timer: timer, isActive: true)
         }
-
-        guard let recent = recentTimer.value.first(where: {$0.id == id}) else {
-            return
-        }
-
-        let timer = Timer(
-            id: UUID(),
-            milliseconds: recent.remainingMillisecond,
-            isRunning: true,
-            currentMilliseconds: recent.remainingMillisecond,
-            sound: recent.sound,
-            label: recent.label
-        )
-        let timerDisplay = TimerMapper.mapToDisplay(timer: timer)
-        let updatedOngoing = ongoingTimer.value + [timerDisplay]
-        updateSortedTimerDisplayRelay(with: updatedOngoing, to: ongoingTimer)
-        createTimerInStorage(timer: timer, isActive: true)
-        return
     }
 
     private func deleteTimer(at indexPath: IndexPath) {
-        switch TimerSectionType(rawValue: indexPath.section) {
-        case .ongoingTimer:
-            var timers = ongoingTimer.value
-            let timer = timers.remove(at: indexPath.row)
-
-            timerUpdateQueue.async {
-                self.ongoingTimer.accept(timers)
+        Task {
+            switch TimerSectionType(rawValue: indexPath.section) {
+            case .ongoingTimer:
+                let deletedTimer = await ongoingTimerActor.delete(at: indexPath.row)
+                ongoingTimer.accept(await ongoingTimerActor.get())
+                deleteTimerFromStorage(id: deletedTimer.id)
+            case .recentTimer:
+                let deletedTimer = await recentTimerActor.delete(at: indexPath.row)
+                recentTimer.accept(await recentTimerActor.get())
+                deleteTimerFromStorage(id: deletedTimer.id)
+            default:
+                return
             }
-
-            deleteTimerFromStorage(id: timer.id)
-        case .recentTimer:
-            var timers = recentTimer.value
-            let timer = timers.remove(at: indexPath.row)
-
-            timerUpdateQueue.async {
-                self.recentTimer.accept(timers)
-            }
-
-            deleteTimerFromStorage(id: timer.id)
-        default:
-            return
         }
     }
 

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerStateActor.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerStateActor.swift
@@ -1,0 +1,34 @@
+//
+//  TimerStateActor.swift
+//  Clock
+//
+//  Created by 이수현 on 5/27/25.
+//
+
+import Foundation
+
+final actor TimerStateActor {
+    private var timers: [TimerDisplay] = []
+
+    func get() -> [TimerDisplay] {
+        timers
+    }
+
+    func update(_ transform: ([TimerDisplay]) -> [TimerDisplay]) {
+        timers = transform(timers)
+            .sorted{ $0.remainingMillisecond < $1.remainingMillisecond }
+    }
+
+    func delete(at index: Int) -> TimerDisplay {
+        timers.remove(at: index)
+    }
+
+    func set(_ timers: [TimerDisplay]) {
+        self.timers = timers
+            .sorted{ $0.remainingMillisecond < $1.remainingMillisecond }
+    }
+
+    func toggleRunnningState(at index: Int) {
+        timers[index].toggleRunningState()
+    }
+}

--- a/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerStateActor.swift
+++ b/Clock/Clock/Presentation/Scene/Timer/ViewModel/TimerStateActor.swift
@@ -16,7 +16,6 @@ final actor TimerStateActor {
 
     func update(_ transform: ([TimerDisplay]) -> [TimerDisplay]) {
         timers = transform(timers)
-            .sorted{ $0.remainingMillisecond < $1.remainingMillisecond }
     }
 
     func delete(at index: Int) -> TimerDisplay {
@@ -25,10 +24,17 @@ final actor TimerStateActor {
 
     func set(_ timers: [TimerDisplay]) {
         self.timers = timers
-            .sorted{ $0.remainingMillisecond < $1.remainingMillisecond }
     }
 
     func toggleRunnningState(at index: Int) {
         timers[index].toggleRunningState()
+    }
+
+    func getTimerIndex(with id: UUID) -> Int? {
+        timers.firstIndex(where: { $0.id == id })
+    }
+
+    func getTimer(with id: UUID) -> TimerDisplay? {
+        timers.first(where: {$0.id == id })
     }
 }


### PR DESCRIPTION
Tick에 대한 로직과 사용자 이벤트(타이머 생성, 수정, 삭제)에 대한 로직을 타이머 배열에 동시에 접근해서 처리했었는데요
이때 타이밍이 잘못되면 업데이트한 타이머 배열이 기존 데이터로 덮어씌어지는 문제가 발생했었습니다.

타이머 배열을 업데이트하는 로직을 직렬 큐를 이용해서 업데이트 순서를 보장하면 해결될거라 생각했는데, 
블로그를 작성하다보니 근본적으로 타이머 배열에 접근할 때 이미 업데이트 된 데이터가 아닌 기존 데이터를 가져와서 처리하더라고요

그래서 Actor로 타이머 배열을 관리하고 actor에 순서대로 접근해서 항상 업데이트된 타이머 데이터를 사용하도록 수정했습니다